### PR TITLE
Style index.html with white background and visible text

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,12 @@
 
     <style>
         :root {
-            --bg: #0f1724;
-            --card: #0b1220;
-            --muted: #9aa6b2;
+            --bg: #ffffff;
+            --card: #f8f9fa;
+            --muted: #6c757d;
             --accent: #00b894;
             --accent-2: #00a1d6;
-            --glass: rgba(255, 255, 255, 0.04);
+            --glass: rgba(0, 0, 0, 0.05);
             --maxw: 1100px;
         }
         
@@ -29,8 +29,8 @@
         body {
             font-family: Inter, system-ui, Arial, sans-serif;
             margin: 0;
-            background: linear-gradient(180deg, #04247b 0%, #13293d 60%);
-            color: #e6eef6;
+            background: linear-gradient(180deg, #f8f9fa 0%, #ffffff 60%);
+            color: #2c3e50;
             line-height: 1.5
         }
         
@@ -90,7 +90,7 @@
         
         .cta {
             background: var(--accent);
-            color: #042;
+            color: #ffffff;
             padding: 10px 14px;
             border-radius: 8px;
             font-weight: 700
@@ -129,19 +129,19 @@
         
         .btn-primary {
             background: var(--accent);
-            color: #042
+            color: #ffffff
         }
         
         .btn-outline {
             background: transparent;
-            border: 1px solid rgba(255, 255, 255, 0.06);
+            border: 1px solid rgba(0, 0, 0, 0.1);
             color: var(--muted)
         }
         
         .hero-right {
             border-radius: 12px;
             overflow: hidden;
-            background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.02), transparent);
             padding: 12px
         }
         
@@ -174,7 +174,7 @@
         }
         
         .service-card {
-            background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.02), transparent);
             padding: 18px;
             border-radius: 12px
         }
@@ -197,7 +197,8 @@
         .project {
             border-radius: 12px;
             overflow: hidden;
-            background: #061022
+            background: #ffffff;
+            border: 1px solid rgba(0, 0, 0, 0.1)
         }
         
         .project img {
@@ -220,7 +221,7 @@
         }
         
         .card {
-            background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.02), transparent);
             padding: 18px;
             border-radius: 12px
         }
@@ -239,7 +240,7 @@
         form textarea {
             padding: 12px;
             border-radius: 8px;
-            border: 1px solid rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(0, 0, 0, 0.1);
             background: transparent;
             color: inherit
         }
@@ -256,7 +257,7 @@
         footer {
             padding: 28px 0;
             color: var(--muted);
-            border-top: 1px solid rgba(255, 255, 255, 0.03)
+            border-top: 1px solid rgba(0, 0, 0, 0.1)
         }
         
         @media (max-width:900px) {
@@ -358,17 +359,17 @@
 
                 <div class="feature-grid">
                     <div class="feature">
-                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none" style="opacity:0.95"><path d="M12 2v4" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none" style="opacity:0.95"><path d="M12 2v4" stroke="#2c3e50" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                         <h4>Custom Software</h4>
                     </div>
 
                     <div class="feature">
-                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none"><path d="M3 12h18" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/></svg>
+                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none"><path d="M3 12h18" stroke="#2c3e50" stroke-width="1.5" stroke-linecap="round"/></svg>
                         <h4>Web Design</h4>
                     </div>
 
                     <div class="feature">
-                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="#fff" stroke-width="1.2"/></svg>
+                        <svg width="36" height="36" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="#2c3e50" stroke-width="1.2"/></svg>
                         <h4>Mobile Apps</h4>
                     </div>
                 </div>


### PR DESCRIPTION
Update `index.html` to change the background to a light theme and improve text visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ae12aa-57c3-4291-b0a8-a4146b45fd12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5ae12aa-57c3-4291-b0a8-a4146b45fd12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

